### PR TITLE
Code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+coverage/
 node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+after_script:
+  - npm run coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/w3c/third-party-resources-checker.svg?branch=master)](https://travis-ci.org/w3c/third-party-resources-checker)
+[![Coverage Status](https://coveralls.io/repos/w3c/third-party-resources-checker/badge.svg)](https://coveralls.io/r/w3c/third-party-resources-checker)
 
 This phantomjs-based tool loads a Web-page and logs on the standard output any URL (one per line) the page requests while loading that is not a `www.w3.org` URL (as defined in the `whitelisted_domains` variable).
 

--- a/package.json
+++ b/package.json
@@ -14,15 +14,17 @@
         "url": "~0.10.1"
     },
     "devDependencies": {
-        "mocha": "1.20.1",
+        "expect.js": "0.3.1",
         "express": "4.4.1",
-        "expect.js": "0.3.1"
+        "istanbul": "^0.3.13",
+        "mocha": "1.20.1"
     },
     "main": "./lib/third-party-resources-checker.js",
     "bin": {
         "third-party-resources-checker": "./bin/third-party-resources-checker"
     },
     "scripts": {
+        "coverage": "istanbul cover _mocha",
         "test": "mocha"
     }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "url": "~0.10.1"
     },
     "devDependencies": {
+        "coveralls": "^2.11.2",
         "expect.js": "0.3.1",
         "express": "4.4.1",
         "istanbul": "^0.3.13",
@@ -25,6 +26,7 @@
     },
     "scripts": {
         "coverage": "istanbul cover _mocha",
+        "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
         "test": "mocha"
     }
 }


### PR DESCRIPTION
Create coverage report `npm run coverage` and then open `coverage/lcov-report/index.html` with your favorite browser.

The report is sent to [Coveralls](https://coveralls.io/r/w3c/third-party-resources-checker) after a build is successful on Travis CI and the README badge then gets updated.

A caveat though, the coverage report is a bit skewed as the only thing that gets covered is the npm module endpoint, but that's the best we can do here:

- `lib/detect-phantom.js`, the script run by PhantomJS, is not instrumented so the coverage report does not cover it. Maybe there is a way to instrument it, but I'd be surprised as it is run in the tests through a `spawn` call.
- `bin/third-party-resources-checker` is the CLI so there is nothing that can be instrumented or covered (and actually, Istanbul does not even see it even when setting `include-all-sources` to `true`)