### PR TITLE
phantomjs upgrade (1.9 -> 2.1) due a to vulnerability with hawk

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "commander": "^2.8.1",
-    "phantomjs": "^1.9.15",
+    "phantomjs": "^2.1.3",
     "promise": "^7.0.1",
     "querystring": "^0.2.0",
     "url": "^0.11.0"


### PR DESCRIPTION
`nsp check` reports a vulnerability with phantomjs 1.9:
```bash
> nsp check
(+) 1 vulnerabilities found
┌───────────────┬───────────────────────────────────────────────────────────────────────────────────────────────┐
│               │ Regular Expression Denial of Service                                                          │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Name          │ hawk                                                                                          │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Installed     │ 1.1.1                                                                                         │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Vulnerable    │ < 3.1.3  || >= 4.0.0 <4.1.1                                                                   │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Patched       │ >=3.1.3 < 4.0.0 || >=4.1.1                                                                    │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ Path          │ third-party-resources-checker@1.0.2 > phantomjs@1.9.19 > request@2.42.0 > hawk@1.1.1          │
├───────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
│ More Info     │ https://nodesecurity.io/advisories/77                                                         │
└───────────────┴───────────────────────────────────────────────────────────────────────────────────────────────┘

```