### PR TITLE
Switch to “phantomjs-prebuilt”

### DIFF
--- a/bin/third-party-resources-checker
+++ b/bin/third-party-resources-checker
@@ -3,7 +3,7 @@
 'use strict';
 
 var fs = require('fs');
-var phantomPath = require('phantomjs').path || '/usr/local/bin/phantomjs';
+var phantomPath = require('phantomjs-prebuilt').path || '/usr/local/bin/phantomjs';
 var program = require('commander');
 var spawn = require('child_process').spawn;
 

--- a/lib/third-party-resources-checker.js
+++ b/lib/third-party-resources-checker.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var fs = require('fs');
-var phantomPath = require('phantomjs').path || '/usr/local/bin/phantomjs';
+var phantomPath = require('phantomjs-prebuilt').path || '/usr/local/bin/phantomjs';
 var Promise = require('promise');
 var script = fs.realpathSync(__dirname + '/detect-phantom.js');
 var spawn = require('child_process').spawn;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "commander": "^2.8.1",
-    "phantomjs": "^2.1.3",
+    "phantomjs-prebuilt": "2.1.7",
     "promise": "^7.0.1",
     "querystring": "^0.2.0",
     "url": "^0.11.0"


### PR DESCRIPTION
Package `phantomjs` is deprecated.

This contributes to fixing w3c/echidna#256.